### PR TITLE
jbcn18-workshop-jenkins-x to 1.0.0

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,9 +1,12 @@
 dependencies:
-- name: exposecontroller
-  version: 2.3.58
+- alias: expose
+  name: exposecontroller
   repository: http://chartmuseum.build.cd.jenkins-x.io
-  alias: expose
-- name: exposecontroller
   version: 2.3.58
+- alias: cleanup
+  name: exposecontroller
   repository: http://chartmuseum.build.cd.jenkins-x.io
-  alias: cleanup
+  version: 2.3.58
+- name: jbcn18-workshop-jenkins-x
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.0


### PR DESCRIPTION
Promote jbcn18-workshop-jenkins-x to version 1.0.0